### PR TITLE
Update for next development version

### DIFF
--- a/connectors/http-connector/pom.xml
+++ b/connectors/http-connector/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.pacesys.openstack4j.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>3.1.1-pureport-1.1</version>
+        <version>3.1.1-pureport-1.2-SNAPSHOT</version>
     </parent>
     <name>OpenStack4j HttpURL Connector</name>
     <artifactId>openstack4j-http-connector</artifactId>

--- a/connectors/httpclient/pom.xml
+++ b/connectors/httpclient/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.pacesys.openstack4j.connectors</groupId>
 		<artifactId>openstack4j-connectors</artifactId>
-		<version>3.1.1-pureport-1.1</version>
+		<version>3.1.1-pureport-1.2-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-httpclient</artifactId>

--- a/connectors/jersey2/pom.xml
+++ b/connectors/jersey2/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.pacesys.openstack4j.connectors</groupId>
 		<artifactId>openstack4j-connectors</artifactId>
-		<version>3.1.1-pureport-1.1</version>
+		<version>3.1.1-pureport-1.2-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-jersey2</artifactId>

--- a/connectors/okhttp/pom.xml
+++ b/connectors/okhttp/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.pacesys.openstack4j.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>3.1.1-pureport-1.1</version>
+        <version>3.1.1-pureport-1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-okhttp</artifactId>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.pacesys</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>3.1.1-pureport-1.1</version>
+        <version>3.1.1-pureport-1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.pacesys.openstack4j.connectors</groupId>

--- a/connectors/resteasy/pom.xml
+++ b/connectors/resteasy/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.pacesys.openstack4j.connectors</groupId>
 		<artifactId>openstack4j-connectors</artifactId>
-		<version>3.1.1-pureport-1.1</version>
+		<version>3.1.1-pureport-1.2-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-resteasy</artifactId>

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.pacesys</groupId>
 		<artifactId>openstack4j-parent</artifactId>
-		<version>3.1.1-pureport-1.1</version>
+		<version>3.1.1-pureport-1.2-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-core-test</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.pacesys</groupId>
 		<artifactId>openstack4j-parent</artifactId>
-		<version>3.1.1-pureport-1.1</version>
+		<version>3.1.1-pureport-1.2-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-core</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.pacesys</groupId>
 		<artifactId>openstack4j-parent</artifactId>
-		<version>3.1.1-pureport-1.1</version>
+		<version>3.1.1-pureport-1.2-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.pacesys</groupId>
     <artifactId>openstack4j-parent</artifactId>
-    <version>3.1.1-pureport-1.1</version>
+    <version>3.1.1-pureport-1.2-SNAPSHOT</version>
     <name>OpenStack4j Parent</name>
     <description>OpenStack Java API</description>
     <url>http://github.com/ContainX/openstack4j/</url>


### PR DESCRIPTION
This is a rebase of old/pureport/develop (b648c1e2)
onto pureport/develop (f274856f)

The rebase looks like:
drop d3036c5b [PE-344] Changes to support automated releases:
drop 7a903352 [PE-344] Add QoS Policy ID to port
drop 4475be55 Feature/pe 344 support listing qos policies (#4)
drop c95b9078 [PE-334] Add ability to set a fixed IP on a network port. (#5)
drop 8424914d [PE-423] Switch to newer gitflow plugin which supports releasing from detached HEAD which is how Jenkins checks out the code from git. (#7)
drop 0594ad6b Set GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL environment variables so that shell git can properly.
drop fab9705c Attempt to use credentials plugin and ssh-agent to configure the key for git.
drop 211d0a0e Update versions for release
drop ce0c5f67 Update for next development version
drop b6a779eb Use sonatype-nexus-releases repository for releases with the Maven Release plugin. Revert back to 1.0-SNAPSHOT. Don't skip the deploy process during the release.
drop e0d7a84a Reverting back to 1.0-SNAPSHOT
drop 3cdb6756 Run deploy post release goal.
drop f884c503 Update versions for release
drop 8aef10e0 Update for next development version
drop 3763da07 Changing dev version to 3.1.1-pureport-1.1-SNAPSHOT
drop 85f7dfb9 Update versions for release
pick 9be2547b Update for next development version
squash b648c1e2 Bumping version to 3.1.1-pureport-1.2-SNAPSHOT

All changes prior to 9be2547b where pulled in from various other commits.

[PE-344]: https://pureport.atlassian.net/browse/PE-344
[PE-344]: https://pureport.atlassian.net/browse/PE-344
[PE-334]: https://pureport.atlassian.net/browse/PE-334
[PE-423]: https://pureport.atlassian.net/browse/PE-423