### PR TITLE
using nexus_credentials for mvn deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,10 @@ pipeline {
                 branch 'pureport/develop'
             }
             steps {
-                script {
-                    sh "mvn deploy"
+                withCredentials([usernamePassword(credentialsId: 'nexus_credentials', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
+                    script {
+                        sh "mvn --settings $WORKSPACE/distribution/settings.xml deploy"
+                    }
                 }
             }
         }

--- a/distribution/settings.xml
+++ b/distribution/settings.xml
@@ -10,5 +10,11 @@
           <username>${env.SONATYPE_USERNAME}</username>
           <password>${env.SONATYPE_PASSWORD}</password>
       </server>
+      <server>
+          <!-- Sonatype Deployment -->
+          <id>sonatype-nexus-releases</id>
+          <username>${env.SONATYPE_USERNAME}</username>
+          <password>${env.SONATYPE_PASSWORD}</password>
+      </server>
   </servers>
 </settings>


### PR DESCRIPTION
* Use `nexus_credentials` jenkins credentials
* Use bundled distribution/settings.xml instead of ~/.m2/settings.xml on eng1
  * Note that eng1 has incorrect credentials in that file for the `admin` user
  * bundled file references environment variables that we are populating with `withCredentials`