### PR TITLE
fix gitflow plugin configuration for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,13 +201,13 @@
                 <artifactId>gitflow-maven-plugin</artifactId>
                 <version>1.11.0</version>
                 <configuration>
-                    <flowInitContext>
+                    <gitFlowConfig>
                         <masterBranchName>pureport/master</masterBranchName>
                         <developBranchName>pureport/develop</developBranchName>
                         <featureBranchPrefix>feature/</featureBranchPrefix>
                         <releaseBranchPrefix>release/</releaseBranchPrefix>
                         <hotfixBranchPrefix>hotfix/</hotfixBranchPrefix>
-                    </flowInitContext>
+                    </gitFlowConfig>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
I've not tested this change yet since it would modify our scm, but this should at least help.

https://jenkins.dev.pureport.com/job/openstack4j/job/pureport%252Fdevelop/7/console failed with 
```
Failed to execute goal com.amashchenko.maven.plugin:gitflow-maven-plugin:1.11.0:release-start (default-cli) on project openstack4j-parent: fatal: 'origin/develop' is not a commit and a branch 'develop' cannot be created from it
```
The documentation at https://github.com/aleksandr-m/gitflow-maven-plugin/tree/v1.11.0#plugin-common-parameters has a different configuration that what we had committed, so updating to align.